### PR TITLE
modernize setup.py a bit

### DIFF
--- a/ci_tools/requirements-pip.txt
+++ b/ci_tools/requirements-pip.txt
@@ -1,8 +1,6 @@
 # --- to execute setup.py whatever the goal
 setuptools_scm
 pytest-runner
-pandoc
-pypandoc
 six
 
 # --- to run the tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "pytest-runner",
+    "setuptools",
+    "setuptools_scm",
+    "six",
+]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ here = path.abspath(path.dirname(__file__))
 # *************** Dependencies *********
 INSTALL_REQUIRES = ['funcsigs;python_version<"3.3"', 'six']
 DEPENDENCY_LINKS = []
-SETUP_REQUIRES = ['pytest-runner', 'setuptools_scm', 'pypandoc', 'pandoc', 'six']
+SETUP_REQUIRES = ['pytest-runner', 'setuptools_scm', 'six']
 TESTS_REQUIRE = ['pytest', 'pytest-logging', 'pytest-cov', 'pytest-cases']
 EXTRAS_REQUIRE = {}
 
@@ -41,14 +41,9 @@ KEYWORDS = 'dynamic function generation definition signature args wrapper'
 # --Get the long description from the README file
 # with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 #    LONG_DESCRIPTION = f.read()
-try:
-    import pypandoc
-    LONG_DESCRIPTION = pypandoc.convert(path.join(here, 'docs', 'long_description.md'), 'rst').replace('\r', '')
-except(ImportError):
-    from warnings import warn
-    warn('WARNING pypandoc could not be imported - we recommend that you install it in order to package the '
-         'documentation correctly')
-    LONG_DESCRIPTION = open('README.md').read()
+
+with open(path.join(here, 'docs', 'long_description.md')) as f:
+    LONG_DESCRIPTION = f.read()
 
 # ************* VERSION **************
 # --Get the Version number from VERSION file, see https://packaging.python.org/single_source_version/ option 4.
@@ -61,6 +56,7 @@ setup(
     name=DISTNAME,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see


### PR DESCRIPTION
- use pyproject.toml so that build deps can be installed with pip instead of easy_install
  (setup_requires is effectively deprecated by PEP 518)
- pypandoc is no longer required for markdown long_description,
  as PyPI supports markdown via long_description_content_type