### PR TITLE
[FIX] Prevent signature symbol to break on TypeError

### DIFF
--- a/makefun/main.py
+++ b/makefun/main.py
@@ -368,7 +368,7 @@ def _signature_symbol_needs_protection(symbol, evaldict):
         try:
             # check if the repr() of the default value is equal to itself.
             return eval(repr(symbol), evaldict) != symbol
-        except (NameError, SyntaxError, TypeError):
+        except Exception:
             # in case of error this needs protection
             return True
     else:

--- a/makefun/main.py
+++ b/makefun/main.py
@@ -368,7 +368,7 @@ def _signature_symbol_needs_protection(symbol, evaldict):
         try:
             # check if the repr() of the default value is equal to itself.
             return eval(repr(symbol), evaldict) != symbol
-        except (NameError, SyntaxError):
+        except (NameError, SyntaxError, TypeError):
             # in case of error this needs protection
             return True
     else:


### PR DESCRIPTION
Hi,

First of all, thanks for `makefun`, very useful !
I came into the situation where I had to modify the signature of a FastAPI endpoint having `Body(default="")` as default value for one of the parameter. Any value other than the empty string for the default value of `Body` would work, but somehow having an empty string leads to a TypeError in the checking for proctection need of the symbol.

`line 370, in _signature_symbol_needs_protection
    return eval(repr(symbol), evaldict) != symbol
  File "<string>", line 1, in <module>
TypeError: Body() missing 1 required positional argument: 'default'
`

This PR fixes this by allowing the handling of TypeError in the `_signature_symbol_needs_protection` function.

Minimal example of breaking code before the PR:

```
from fastapi import Body
from makefun import wraps, add_signature_parameters
import inspect


def my_function(a: str, b: str = Body(default="")) -> str:
    return "hello"

fn_signature = inspect.signature(my_function)

modified_fn_sig = add_signature_parameters(
    fn_signature,
    last=inspect.Parameter(
        "new_param",
        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
        default='abc',
    ),
)

@wraps(my_function, new_sig=modified_fn_sig)
def wrapped_function(
    *args,
    new_param= "abc",
    **kwargs,
):
    return True

```