### PR TITLE
Fixed `ValueError: Invalid co_name` on python 2 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 1.15.1 - bugfixes
+
+ - Fixed `ValueError: Invalid co_name` happening on python 2 when the name of a function to create starts or ends with
+   `_` or contains a double `__` . Fixes [#91](https://github.com/smarie/python-makefun/issues/91)
+
 ### 1.15.0 - More PEP-compliant `wraps`
 
  - `wraps` now always sets the `__wrapped__` attribute, and also sets the `__signature__` attribute when the signature changes, as specified by PEP 362. PR []() by [#86](https://github.com/smarie/python-makefun/pull/86) by [lucaswiman](https://github.com/lucaswiman).

--- a/src/makefun/main.py
+++ b/src/makefun/main.py
@@ -27,7 +27,7 @@ else:
         """
         if len(string) == 0 or string[0].isdigit():
             return False
-        return all([s.isalnum() for s in string.split("_")])
+        return all([(len(s) == 0) or s.isalnum() for s in string.split("_")])
 
 try:  # python 3.3+
     from inspect import signature, Signature, Parameter

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -3,6 +3,8 @@ import sys
 
 import pytest
 
+from makefun.main import is_identifier
+
 try:  # python 3.3+
     from inspect import signature, Signature, Parameter
 except ImportError:
@@ -254,7 +256,6 @@ def test_issue_77_async_generator_partial():
     assert asyncio.get_event_loop().run_until_complete(asyncio.ensure_future(f_partial().__anext__())) == 1
 
 
-
 @pytest.mark.skipif(sys.version_info < (3, 7, 6), reason="The __wrapped__ behavior in get_type_hints being tested was not added until python 3.7.6.")
 def test_issue_85_wrapped_forwardref_annotation():
     import typing
@@ -274,3 +275,9 @@ def test_issue_85_wrapped_forwardref_annotation():
         "return": _issue_85_module.ForwardRef,
     }
     assert typing.get_type_hints(wrapper) == expected_annotations
+
+
+def test_issue_91():
+    """This test should work also in python 2 ! """
+    assert is_identifier("_results_bag")
+    assert is_identifier("hello__bag")


### PR DESCRIPTION
Fixes #91