### PR TITLE
Match type exactly when checking TYPES_WITH_SAFE_REPR

### DIFF
--- a/src/makefun/main.py
+++ b/src/makefun/main.py
@@ -466,7 +466,7 @@ def _signature_symbol_needs_protection(symbol, evaldict):
     :param symbol:
     :return:
     """
-    if symbol is not None and symbol is not Parameter.empty and not isinstance(symbol, TYPES_WITH_SAFE_REPR):
+    if symbol is not None and symbol is not Parameter.empty and type(symbol) not in TYPES_WITH_SAFE_REPR:
         try:
             # check if the repr() of the default value is equal to itself.
             return eval(repr(symbol), evaldict) != symbol  # noqa  # we cannot use ast.literal_eval, too restrictive

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -283,12 +283,14 @@ def test_issue_91():
 
 
 def test_issue_98():
-    from enum import StrEnum
+    class A(str):
+        def __str__(self):
+            return 'custom str'
 
-    class A(StrEnum):
-        a = 'a'
+        def __repr__(self):
+            return 'custom repr'
 
-    def foo(a=A.a):
+    def foo(a=A()):
         pass
 
     @wraps(foo)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -280,3 +280,17 @@ def test_issue_91():
     """This test should work also in python 2 ! """
     assert is_identifier("_results_bag")
     assert is_identifier("hello__bag")
+
+
+def test_issue_98():
+    from enum import StrEnum
+
+    class A(StrEnum):
+        a = 'a'
+
+    def foo(a=A.a):
+        pass
+
+    @wraps(foo)
+    def test(*args, **kwargs):
+        return foo(*args, **kwargs)


### PR DESCRIPTION
This fixes #98 

My understanding is that here we are trying to say whether a builtin literal for str, int, bytes, or bool would produce the same value as given. However, that is only possible if the given value has one of these types.