### PR TITLE
Fix tests on Python 3.12.4

### DIFF
--- a/tests/test_partial_and_macros.py
+++ b/tests/test_partial_and_macros.py
@@ -161,11 +161,12 @@ def test_args_order_and_kind():
         # it is possible to keyword-partialize a positional-only argument...
         fp_ref = functools.partial(f, b=0)
 
-        # but 'signature' does not support it !
-        with pytest.raises(ValueError):
-            signature(fp_ref)
-
-        # assert str(signature(fp_ref)) == "(c, /, *, d, **e)"
+        # but 'signature' does not support it before Python 3.12.4 !
+        if sys.version_info < (3, 12, 4):
+            with pytest.raises(ValueError):
+                signature(fp_ref)
+        else:
+            assert str(signature(fp_ref)) == "(a, c, /, *, d, **e)"
 
         # so we do not support it
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
Starting with Python 3.12.4, it is now possible to get a `signature()` of `partial()`.  Update the test accordingly.