### PR TITLE
Specify pytest asyncio mode (there is no default in later versions)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,7 @@ addopts =
     --verbose
     --doctest-modules
     --ignore-glob='**/_*.py'
+    --asyncio-mode=auto
 
 # we need the 'always' for python 2 tests to work see https://github.com/pytest-dev/pytest/issues/2917
 filterwarnings =


### PR DESCRIPTION
In later versions of pytest, there is no default value for 'asyncio-mode', which causes the tests to be skipped.